### PR TITLE
Change CellConvertible to Reusable CellConvertible in CellModel

### DIFF
--- a/Cell.xctemplate/___VARIABLE_sourceCellIdentifier___CellModel.swift
+++ b/Cell.xctemplate/___VARIABLE_sourceCellIdentifier___CellModel.swift
@@ -12,7 +12,7 @@ struct ___VARIABLE_sourceCellIdentifier___CellModel {
 
 }
 
-extension ___VARIABLE_sourceCellIdentifier___CellModel: CellConvertible {
+extension ___VARIABLE_sourceCellIdentifier___CellModel: ReusableCellConvertible {
     typealias Cell = ___VARIABLE_sourceCellIdentifier___Cell
 
     var cellHeight: CGFloat {


### PR DESCRIPTION
- change cell model's protocol conformance from CellConvertible to ReusableCellConvertible so we can automatically use CellKit's lazy loading