### PR TITLE
Housekeep: Change class to AnyObject

### DIFF
--- a/MVVM-C/MVVM-C Modal Scene.xctemplate/___VARIABLE_sceneIdentifier___ViewModel.swift
+++ b/MVVM-C/MVVM-C Modal Scene.xctemplate/___VARIABLE_sceneIdentifier___ViewModel.swift
@@ -12,7 +12,7 @@ import FuntastyKit
 protocol ___VARIABLE_sceneIdentifier___CoordinatorInput: Coordinator {
 }
 
-protocol ___VARIABLE_sceneIdentifier___ViewControllerInput: class {
+protocol ___VARIABLE_sceneIdentifier___ViewControllerInput: AnyObject {
 }
 
 final class ___VARIABLE_sceneIdentifier___ViewModel {

--- a/MVVM-C/MVVM-C Push Scene.xctemplate/___VARIABLE_sceneIdentifier___ViewModel.swift
+++ b/MVVM-C/MVVM-C Push Scene.xctemplate/___VARIABLE_sceneIdentifier___ViewModel.swift
@@ -12,7 +12,7 @@ import FuntastyKit
 protocol ___VARIABLE_sceneIdentifier___CoordinatorInput: Coordinator {
 }
 
-protocol ___VARIABLE_sceneIdentifier___ViewControllerInput: class {
+protocol ___VARIABLE_sceneIdentifier___ViewControllerInput: AnyObject {
 }
 
 final class ___VARIABLE_sceneIdentifier___ViewModel {

--- a/MVVM-C/MVVM-C Scene.xctemplate/___VARIABLE_sceneIdentifier___ViewModel.swift
+++ b/MVVM-C/MVVM-C Scene.xctemplate/___VARIABLE_sceneIdentifier___ViewModel.swift
@@ -12,7 +12,7 @@ import FuntastyKit
 protocol ___VARIABLE_sceneIdentifier___CoordinatorInput: Coordinator {
 }
 
-protocol ___VARIABLE_sceneIdentifier___ViewControllerInput: class {
+protocol ___VARIABLE_sceneIdentifier___ViewControllerInput: AnyObject {
 }
 
 final class ___VARIABLE_sceneIdentifier___ViewModel {

--- a/MVVM-C/MVVM-C Show Scene.xctemplate/___VARIABLE_sceneIdentifier___ViewModel.swift
+++ b/MVVM-C/MVVM-C Show Scene.xctemplate/___VARIABLE_sceneIdentifier___ViewModel.swift
@@ -12,7 +12,7 @@ import FuntastyKit
 protocol ___VARIABLE_sceneIdentifier___CoordinatorInput: Coordinator {
 }
 
-protocol ___VARIABLE_sceneIdentifier___ViewControllerInput: class {
+protocol ___VARIABLE_sceneIdentifier___ViewControllerInput: AnyObject {
 }
 
 final class ___VARIABLE_sceneIdentifier___ViewModel {

--- a/MVVM-C/MVVM-C Tab Bar Item Scene.xctemplate/___VARIABLE_sceneIdentifier___ViewModel.swift
+++ b/MVVM-C/MVVM-C Tab Bar Item Scene.xctemplate/___VARIABLE_sceneIdentifier___ViewModel.swift
@@ -12,7 +12,7 @@ import FuntastyKit
 protocol ___VARIABLE_sceneIdentifier___CoordinatorInput: Coordinator {
 }
 
-protocol ___VARIABLE_sceneIdentifier___ViewControllerInput: class {
+protocol ___VARIABLE_sceneIdentifier___ViewControllerInput: AnyObject {
 }
 
 final class ___VARIABLE_sceneIdentifier___ViewModel {

--- a/MVVM-C/MVVM-C Window Scene.xctemplate/___VARIABLE_sceneIdentifier___ViewModel.swift
+++ b/MVVM-C/MVVM-C Window Scene.xctemplate/___VARIABLE_sceneIdentifier___ViewModel.swift
@@ -12,7 +12,7 @@ import FuntastyKit
 protocol ___VARIABLE_sceneIdentifier___CoordinatorInput: Coordinator {
 }
 
-protocol ___VARIABLE_sceneIdentifier___ViewControllerInput: class {
+protocol ___VARIABLE_sceneIdentifier___ViewControllerInput: AnyObject {
 }
 
 final class ___VARIABLE_sceneIdentifier___ViewModel {


### PR DESCRIPTION
`class` keyword is kind of deprected:

- https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md#class-and-anyobject
- https://sarunw.com/posts/class-only-protocols-class-or-anyobject/

And we use a linting rule for it on most projects.